### PR TITLE
fix: upgrade cross-spawn version to 7.0.5 as per snyk suggestion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "dependencies": {
         "chalk": "4.1.2",
         "check-types": "7.4.0",
-        "cross-spawn": "7.0.3",
+        "cross-spawn": "7.0.5",
         "mkdirp": "1.0.4",
         "needle": "^3.3.1",
         "pino": "^8.21.0",
@@ -342,6 +342,66 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pact-foundation/pact-cli-darwin-arm64": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-darwin-arm64/-/pact-cli-darwin-arm64-16.0.3.tgz",
+      "integrity": "sha512-DnwBjH1k8H8mS5dTS7X3YSx7KSWPqX/G/+5Qt13mrdWz1G1FlzkGZJ/fKfUR8DsugMX0AXdJaXRP+G+/BE69DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-darwin-x64": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-darwin-x64/-/pact-cli-darwin-x64-16.0.3.tgz",
+      "integrity": "sha512-gGF5dfgA09yqCv7KZeDjewoUw3B9FRRwehajqZR8qU2Fb4pIGtiWnG1t5B/e0lQn5yCCBqiHmEVO56JFgkyblA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-linux-arm64": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-linux-arm64/-/pact-cli-linux-arm64-16.0.3.tgz",
+      "integrity": "sha512-u7n98sjFnyy5QmHDfozoxsf2bhv7Hx1n3qIPeAcLSGOXkwnVKEuVY7C0oLj3o5VDQEd/k2xap2BGcMArQeexdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-linux-x64": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-linux-x64/-/pact-cli-linux-x64-16.0.3.tgz",
+      "integrity": "sha512-C7Ua/BBS1BqOKOpSaHJkscMhdZYgRzOS6GSRbcv2t6i8KMj7WZF3vBXx6MZifDTexf7p13Bt8r5SsDn3hkV90A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-windows-x64": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-windows-x64/-/pact-cli-windows-x64-16.0.3.tgz",
+      "integrity": "sha512-1EjVaAu7LeopHLgGlVH2W0fXCsNEfUjs6X/c9whgstOFPOTT1irFGnMo+5LKwoK1uVqS/P7t71dDu93gpVYsHw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pact-foundation/pact-js-prettier-config": {
       "version": "1.0.0",
@@ -1978,8 +2038,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "chalk": "4.1.2",
     "check-types": "7.4.0",
-    "cross-spawn": "7.0.3",
+    "cross-spawn": "7.0.5",
     "mkdirp": "1.0.4",
     "needle": "^3.3.1",
     "pino": "^8.21.0",


### PR DESCRIPTION
### PR Template

Upgrading `cross-spawn` version to `7.0.5` as per snyk suggestion (https://security.snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230) in order to fix that version ReDoS vulnerability

Ran local tests without errors