### PR TITLE
fix(typo): update package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ LOG_LEVEL=debug
 ### Pact Broker Publishing
 
 ```js
-var pact = require('@pact-foundation/pact-core');
+var pact = require('@pact-foundation/pact-cli');
 var opts = {
  ...
 };
@@ -178,7 +178,7 @@ pact.publishPacts(opts).then(function () {
 ### Pact Broker Deployment Check
 
 ```js
-var pact = require('@pact-foundation/pact-core');
+var pact = require('@pact-foundation/pact-cli');
 var opts = {
  ...
 };


### PR DESCRIPTION
### PR Template

Update the typo in the readme file (where pact is imported from `@pact-foundation/pact-core` instead of `@pact-foundation/pact-cli`, which is a little misleading in this context).