### PR TITLE
fix: simplify argument parsing

### DIFF
--- a/bin/pact-broker.ts
+++ b/bin/pact-broker.ts
@@ -1,21 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().brokerFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-message.ts
+++ b/bin/pact-message.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().messageFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-mock-server.ts
+++ b/bin/pact-mock-server.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().mockServerFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-mock-service.ts
+++ b/bin/pact-mock-service.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().mockServiceFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-plugin.ts
+++ b/bin/pact-plugin.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().pluginFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-provider-verifier.ts
+++ b/bin/pact-provider-verifier.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().verifierFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-stub-server.ts
+++ b/bin/pact-stub-server.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().stubServerFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-stub-service.ts
+++ b/bin/pact-stub-service.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
-  standalone().stubFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+const { error, status } = spawnSync(
+  standalone().stubServerFullPath,
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact-verifier.ts
+++ b/bin/pact-verifier.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
-  standalone().verifierRustFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+const { error, status } = spawnSync(
+  standalone().verifierFullPath,
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pact.ts
+++ b/bin/pact.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().pactFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/bin/pactflow.ts
+++ b/bin/pactflow.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
-import childProcess = require('child_process');
-import {
-  standalone,
-  standaloneUseShell,
-  setStandaloneArgs,
-} from '../src/pact-standalone';
+import { spawnSync, standalone } from '../src/pact-standalone';
 
-const args = process.argv.slice(2);
-const opts = standaloneUseShell ? { shell: true } : {};
-
-const { error, status } = childProcess.spawnSync(
+const { error, status } = spawnSync(
   standalone().pactflowFullPath,
-  setStandaloneArgs(args, standaloneUseShell),
-  {
-    stdio: 'inherit',
-    ...opts,
-  }
+  process.argv.slice(2)
 );
 if (error) throw error;
 process.exit(status as number);

--- a/src/pact-environment.ts
+++ b/src/pact-environment.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 export class PactEnvironment {
   public get cwd(): string {
@@ -6,7 +6,7 @@ export class PactEnvironment {
   }
 
   public isWindows(platform: string = process.platform): boolean {
-    return platform === 'win32';
+    return platform === 'win32' || platform === 'cygwin';
   }
 }
 

--- a/src/pact-standalone.spec.ts
+++ b/src/pact-standalone.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as chai from 'chai';
 import os from 'os';
-import { getExePath, PactStandalone, standalone } from './pact-standalone';
+import { getExePath, type PactStandalone, standalone } from './pact-standalone';
 
 const { expect } = chai;
 const basePath = getExePath();


### PR DESCRIPTION
Get rid of the bespoke argument escaping, and instead spawn subprocesses directly. The arguments from `process.argv` and passed through `spawnSync` are already escaped (as we are spawning directly).

This also removes the use of `shell` to avoid issues that might arise from using shells.

Ref: #99