### PR TITLE
fix(win): wrap command in double quotes to handle paths with spaces

### DIFF
--- a/src/pact-standalone.ts
+++ b/src/pact-standalone.ts
@@ -45,6 +45,11 @@ export function spawnSync(
   const isWindowsBatFile =
     pactEnvironment.isWindows() && command.endsWith('.bat');
 
+  if (pactEnvironment.isWindows()) {
+    // eslint-disable-next-line no-param-reassign
+    command = `"${command}"`;
+  }
+
   const spawnOptions: childProcess.SpawnSyncOptions = {
     stdio: 'inherit',
     ...(isWindowsBatFile && { shell: true }),


### PR DESCRIPTION
follows on from #100 

tested in git bash / powershell and cmd prompt with paths with spaces and without.

previous testing was using npm link, from a folder without spaces in unfortunately.

Change is scoped for windows only, as macos/linux will error if the command is quoted