### PR TITLE
chore: correct install.ts path and shellcheck lints in create-pr script

### DIFF
--- a/script/create-pr-to-update-pact-standalone.sh
+++ b/script/create-pr-to-update-pact-standalone.sh
@@ -10,17 +10,17 @@ DASHERISED_VERSION=$(echo "${STANDALONE_VERSION}" | sed 's/\./\-/g')
 BRANCH_NAME="chore/upgrade-to-pact-standalone-${DASHERISED_VERSION}"
 
 git checkout main
-git checkout standalone/install.ts
+git checkout src/install.ts
 git pull origin main
 
-git checkout -b ${BRANCH_NAME}
+git checkout -b "${BRANCH_NAME}"
 
-cat standalone/install.ts | sed "s/export const PACT_STANDALONE_VERSION.*/export const PACT_STANDALONE_VERSION = '${STANDALONE_VERSION}';/" > tmp-install
-mv tmp-install standalone/install.ts
+cat src/install.ts | sed "s/export const PACT_STANDALONE_VERSION.*/export const PACT_STANDALONE_VERSION = '${STANDALONE_VERSION}';/" >tmp-install
+mv tmp-install src/install.ts
 
-git add standalone/install.ts
+git add src/install.ts
 git commit -m "${TYPE}: update standalone to ${STANDALONE_VERSION}"
-git push --set-upstream origin ${BRANCH_NAME}
+git push --set-upstream origin "${BRANCH_NAME}"
 
 gh pr create --title "${TYPE}: update standalone to ${STANDALONE_VERSION}" --fill
 


### PR DESCRIPTION
The file moved from standalone/install.ts to src/install.ts. Also quote BRANCH_NAME to prevent word splitting (SC2086).
